### PR TITLE
Add CACHE_DIR environment variable for managing cache

### DIFF
--- a/audioldm/__init__.py
+++ b/audioldm/__init__.py
@@ -6,6 +6,12 @@ import os
 import urllib.request
 import progressbar
 
+
+CACHE_DIR = os.getenv(
+    "AUDIOLDM_CACHE_DIR",
+    os.path.join(os.path.expanduser("~"), ".cache"))
+
+
 class MyProgressBar():
     def __init__(self):
         self.pbar = None
@@ -24,8 +30,8 @@ class MyProgressBar():
 meta = {
     "audioldm": {
         "path": os.path.join(
-            os.path.expanduser("~"),
-            ".cache/audioldm/audioldm-s-full.ckpt",
+            CACHE_DIR,
+            "audioldm-s-full.ckpt",
         ),
         "url": "https://zenodo.org/record/7600541/files/audioldm-s-full?download=1",
     },
@@ -33,7 +39,7 @@ meta = {
 
 if not os.path.exists(meta["audioldm"]["path"]) or os.path.getsize(meta["audioldm"]["path"]) < 2*10**9:
     os.makedirs(os.path.dirname(meta["audioldm"]["path"]), exist_ok=True)
-    print("Downloading the main structure of audioldm")
+    print(f"Downloading the main structure of audioldm into {os.path.dirname(meta['audioldm']['path'])}")
 
     urllib.request.urlretrieve(meta["audioldm"]["url"], meta["audioldm"]["path"], MyProgressBar())
     print(

--- a/audioldm/__init__.py
+++ b/audioldm/__init__.py
@@ -9,7 +9,7 @@ import progressbar
 
 CACHE_DIR = os.getenv(
     "AUDIOLDM_CACHE_DIR",
-    os.path.join(os.path.expanduser("~"), ".cache"))
+    os.path.join(os.path.expanduser("~"), ".cache/audioldm"))
 
 
 class MyProgressBar():

--- a/audioldm/__main__.py
+++ b/audioldm/__main__.py
@@ -5,6 +5,11 @@ import argparse
 
 parser = argparse.ArgumentParser()
 
+CACHE_DIR = os.getenv(
+    "AUDIOLDM_CACHE_DIR",
+    os.path.join(os.path.expanduser("~"), ".cache"))
+
+
 parser.add_argument(
     "--mode",
     type=str,
@@ -56,8 +61,8 @@ parser.add_argument(
     required=False,
     help="The path to the pretrained .ckpt model",
     default=os.path.join(
-                os.path.expanduser("~"),
-                ".cache/audioldm/audioldm-s-full.ckpt",
+                CACHE_DIR,
+                "audioldm-s-full.ckpt",
             ),
 )
 

--- a/audioldm/__main__.py
+++ b/audioldm/__main__.py
@@ -7,7 +7,7 @@ parser = argparse.ArgumentParser()
 
 CACHE_DIR = os.getenv(
     "AUDIOLDM_CACHE_DIR",
-    os.path.join(os.path.expanduser("~"), ".cache"))
+    os.path.join(os.path.expanduser("~"), ".cache/audioldm"))
 
 
 parser.add_argument(

--- a/audioldm/clap/open_clip/factory.py
+++ b/audioldm/clap/open_clip/factory.py
@@ -15,7 +15,7 @@ from .transform import image_transform
 
 _MODEL_CONFIG_PATHS = [Path(__file__).parent / f"model_configs/"]
 _MODEL_CONFIGS = {}  # directory (model_name: config) of model architecture configs
-CACHE_DIR = os.getenv("AUDIOLDM_CACHE_DIR", "~/.cache")
+CACHE_DIR = os.getenv("AUDIOLDM_CACHE_DIR", "~/.cache/audioldm")
 
 
 

--- a/audioldm/clap/open_clip/factory.py
+++ b/audioldm/clap/open_clip/factory.py
@@ -15,6 +15,8 @@ from .transform import image_transform
 
 _MODEL_CONFIG_PATHS = [Path(__file__).parent / f"model_configs/"]
 _MODEL_CONFIGS = {}  # directory (model_name: config) of model architecture configs
+CACHE_DIR = os.getenv("AUDIOLDM_CACHE_DIR", "~/.cache")
+
 
 
 def _natural_key(string_):
@@ -75,7 +77,7 @@ def create_model(
     device: torch.device = torch.device("cpu"),
     jit: bool = False,
     force_quick_gelu: bool = False,
-    openai_model_cache_dir: str = os.path.expanduser("~/.cache/clip"),
+    openai_model_cache_dir: str = os.path.expanduser(f"{CACHE_DIR}/clip"),
     skip_params=True,
     pretrained_audio: str = "",
     pretrained_text: str = "",

--- a/audioldm/clap/open_clip/openai.py
+++ b/audioldm/clap/open_clip/openai.py
@@ -18,6 +18,9 @@ from .pretrained import (
 
 __all__ = ["list_openai_models", "load_openai_model"]
 
+CACHE_DIR = os.getenv("AUDIOLDM_CACHE_DIR", "~/.cache")
+
+
 
 def list_openai_models() -> List[str]:
     """Returns the names of available CLIP models"""
@@ -29,7 +32,7 @@ def load_openai_model(
     model_cfg,
     device: Union[str, torch.device] = "cuda" if torch.cuda.is_available() else "cpu",
     jit=True,
-    cache_dir=os.path.expanduser("~/.cache/clip"),
+    cache_dir=os.path.expanduser(f"{CACHE_DIR}/clip"),
     enable_fusion: bool = False,
     fusion_type: str = "None",
 ):

--- a/audioldm/clap/open_clip/pretrained.py
+++ b/audioldm/clap/open_clip/pretrained.py
@@ -5,6 +5,8 @@ import warnings
 
 from tqdm import tqdm
 
+CACHE_DIR = os.getenv("AUDIOLDM_CACHE_DIR", "~/.cache")
+
 _RN50 = dict(
     openai="https://openaipublic.azureedge.net/clip/models/afeb0e10f9e5a86da6080e35cf09123aca3b358a0c3e3b6c78a7b63bc04b6762/RN50.pt",
     yfcc15m="https://github.com/mlfoundations/open_clip/releases/download/v0.2-weights/rn50-quickgelu-yfcc15m-455df137.pt",
@@ -112,7 +114,7 @@ def get_pretrained_url(model: str, tag: str):
     return model_pretrained[tag]
 
 
-def download_pretrained(url: str, root: str = os.path.expanduser("~/.cache/clip")):
+def download_pretrained(url: str, root: str = os.path.expanduser(f"{CACHE_DIR}/clip")):
     os.makedirs(root, exist_ok=True)
     filename = os.path.basename(url)
 

--- a/audioldm/clap/training/params.py
+++ b/audioldm/clap/training/params.py
@@ -1,4 +1,10 @@
 import argparse
+import os
+
+CACHE_DIR = os.getenv(
+    "AUDIOLDM_CACHE_DIR",
+    "~/.cache")
+
 
 
 def get_default_params(model_name):
@@ -426,7 +432,7 @@ def parse_args():
     parser.add_argument(
         "--openai-model-cache-dir",
         type=str,
-        default="~/.cache/clip",
+        default=f"{CACHE_DIR}/clip",
         help="Directory to download OpenAI models.",
     )
     parser.add_argument(

--- a/audioldm/pipeline.py
+++ b/audioldm/pipeline.py
@@ -17,7 +17,7 @@ import time
 
 CACHE_DIR = os.getenv(
     "AUDIOLDM_CACHE_DIR",
-    os.path.join(os.path.expanduser("~"), ".cache"))
+    os.path.join(os.path.expanduser("~"), ".cache/audioldm"))
 
 
 def make_batch_for_text_to_audio(text, batchsize=1):

--- a/audioldm/pipeline.py
+++ b/audioldm/pipeline.py
@@ -15,6 +15,11 @@ from einops import repeat
 import time
 
 
+CACHE_DIR = os.getenv(
+    "AUDIOLDM_CACHE_DIR",
+    os.path.join(os.path.expanduser("~"), ".cache"))
+
+
 def make_batch_for_text_to_audio(text, batchsize=1):
     text = [text] * batchsize
     if batchsize < 1:
@@ -35,10 +40,7 @@ def make_batch_for_text_to_audio(text, batchsize=1):
 
 
 def build_model(
-    ckpt_path=os.path.join(
-        os.path.expanduser("~"),
-        ".cache/audioldm/audioldm-s-full.ckpt",
-    ),
+    ckpt_path=os.path.join(CACHE_DIR, "audioldm-s-full.ckpt"),
     config=None,
 ):
     if torch.cuda.is_available():


### PR DESCRIPTION
This PR allows dynamic setting of a CACHE_DIR by users.

If `AUDIOLDM_CACHE_DIR` environment variable is set, it will be used instead of the default `~/.cache`.
