### PR TITLE
Update app.py

### DIFF
--- a/app.py
+++ b/app.py
@@ -331,4 +331,4 @@ with iface:
 
 iface.queue(concurrency_count=3)
 # iface.launch(debug=True)
-iface.launch(debug=True, share=True)
+iface.launch(debug=True, share=False)


### PR DESCRIPTION
Using Share=True for gradio causes a security risk as it creates a url that is publicly accessible by anyone. This link can be exploited. also, the proxy gradio uses by this is flagged as a virus by antiviruses so ends up getting deleted at times According to Gradio: 
>>> Keep in mind, however, that these links are publicly accessible, meaning that anyone can use your model for prediction! Therefore, make sure not to expose any sensitive information through the functions you write, or allow any critical changes to occur on your device.